### PR TITLE
docs: improve README documentation and configuration clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,12 @@ Add the Weaviate MCP server to your MCP settings file (typically `claude_desktop
 
 | Option | Description | Default | Environment Variable |
 |--------|-------------|---------|---------------------|
-| `--connection-type` | Connection type: "local" or "cloud" | local | - |
-| `--host` | Host for local connection | localhost | - |
-| `--port` | HTTP port for local connection | 8080 | - |
-| `--grpc-port` | gRPC port for local connection | 50051 | - |
-| `--cluster-url` | Weaviate Cloud Services URL | - | WEAVIATE_CLUSTER_URL |
-| `--api-key` | API key for authentication | - | WEAVIATE_API_KEY |
+| `--connection-type` | Connection type: "local" or "cloud" | *required* | - |
+| `--host` | Host for local connection | *required for local* | - |
+| `--port` | HTTP port for local connection | *required for local* | - |
+| `--grpc-port` | gRPC port for local connection | *required for local* | - |
+| `--cluster-url` | Weaviate Cloud Services URL | *required for cloud* | WEAVIATE_CLUSTER_URL |
+| `--api-key` | API key for authentication | *required for cloud* | WEAVIATE_API_KEY |
 | `--openai-api-key` | OpenAI API key for embeddings | - | OPENAI_API_KEY |
 | `--cohere-api-key` | Cohere API key for embeddings | - | COHERE_API_KEY |
 | `--timeout-init` | Initialization timeout (seconds) | 30 | - |


### PR DESCRIPTION
## What this PR does

This PR improves the README documentation and configuration management by:

- Updating configuration options table to correctly reflect that connection parameters are required rather than having incorrect default values
- Simplifying the Quick Start section to focus on uvx installation method
- Removing outdated installation methods and excessive usage examples
- Updating environment variable examples to show required parameters clearly
- Streamlining MCP configuration examples to use uvx instead of uv with complex paths

## Why it's needed

The previous README had incorrect default values in the configuration table (showing localhost:8080 as defaults when these parameters are actually required). This was misleading for users trying to configure the MCP server. The documentation also contained outdated installation methods and overly complex configuration examples that didn't reflect the current streamlined approach using uvx.

These changes make the documentation more accurate and user-friendly by clearly indicating which parameters are required for each connection type and providing simpler, more direct configuration examples.